### PR TITLE
Fix "module 'astroid' has no attribute 'Discard'"

### DIFF
--- a/pylint_odoo/checkers/itp_checks.py
+++ b/pylint_odoo/checkers/itp_checks.py
@@ -3,11 +3,15 @@ import re
 import ast
 import os
 import types
-import astroid
 import sys
 from pylint.checkers import BaseChecker, utils
 from pylint.interfaces import IAstroidChecker
 from .. import misc, settings
+
+try:
+    from astroid import Discard as Expr
+except ImportError:
+    from astroid import Expr
 
 def _is_string_instance(obj):
 	try:
@@ -96,7 +100,7 @@ class ITPModuleChecker(misc.WrapperModuleChecker):
     @utils.check_messages('manifest-template-field')
     def visit_dict(self, node):
         if not os.path.basename(self.linter.current_file) in settings.MANIFEST_FILES \
-                or not isinstance(node.parent, astroid.Discard):
+                or not isinstance(node.parent, Expr):
             return
         manifest_dict = ast.literal_eval(node.as_string())
 


### PR DESCRIPTION
Since astroid 1.4.0 Discard is deprecated in favor of Expr.

https://github.com/PyCQA/astroid/blob/4edd2201d76f82683ffe175fd633a3bfe7de6b76/ChangeLog#L1087-L1099